### PR TITLE
fix: add install readme+repo link in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ Congrats! You just saved yourself hours of work by bootstrapping this project wi
 
 > If you’re new to TypeScript and React, checkout [this handy cheatsheet](https://github.com/sw-yx/react-typescript-cheatsheet/)
 
+## Usage
+
+To install `mantine-layout-componenst` via `npm`:
+
+```bash
+npm install mantine-layout-components
+```
+
 ## Commands
 
 DTS scaffolds your new library inside `/src`, and also sets up a [Vite-based](https://vitejs.dev) playground for it inside `/example`.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "license": "MIT",
   "author": "Kitze",
+  "repository": "kitze/mantine-layout-components",
   "main": "dist/index.js",
   "module": "dist/mantine-layout-components.esm.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
- npm install in the readme for lazy people like me to copy and paste to install the lib
- add a link to the repository in the package.json so we can navigate easily from the npm page to here because google search "mantine layout components" was frustrating asf (i believe it requires a version release to reflect that in the npm page)