### PR TITLE
destructuring commonProps values to avoid React warning/error

### DIFF
--- a/src/Horizontal/index.tsx
+++ b/src/Horizontal/index.tsx
@@ -7,8 +7,22 @@ export type HorizontalProps = GroupProps & CommonProps;
 
 export const Horizontal: ReactFC<HorizontalProps> = forwardRef(
   (props, ref: any) => {
-    const { children, center, fullW, centerV, centerH, debug, sx, ...rest } =
-      props;
+    const { 
+      alignEnd,
+      center,
+      centerH,
+      centerV,
+      children,
+      debug,
+      fullH,
+      fullW,
+      noWrap,
+      scrollable,
+      spaceBetween,
+      sx,
+      sxArray,
+      ...rest 
+    } = props;
 
     return (
       <Group

--- a/src/Vertical/index.tsx
+++ b/src/Vertical/index.tsx
@@ -14,14 +14,19 @@ export type VerticalProps = StackProps & CommonProps;
 export const Vertical: ReactFC<VerticalProps> = forwardRef<any, VerticalProps>(
   (props, ref) => {
     const {
-      children,
-      sxArray = [],
+      alignEnd,
       center,
-      fullW,
-      centerV,
       centerH,
+      centerV,
+      children,
       debug,
+      fullH,
+      fullW,
+      noWrap,
+      scrollable,
+      spaceBetween,
       sx,
+      sxArray = [],
       ...rest
     } = props;
 


### PR DESCRIPTION
fixes the warning / error in the console:

![CleanShot 2023-07-30 at 18 31 51](https://github.com/kitze/mantine-layout-components/assets/829902/64f6fcda-c33d-4689-b7ac-0f99a5807073)
