### PR TITLE
feat: enable dependabot workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
**Context:** 

I noticed that the package relies on an older version of `@mantine/core`.



**Intention:** 

keep the dependencies up to date automatically.



**Note:**

Currently, it is configured on a weekly cadence, maybe worth moving to a monthly one? 🤔 

## TODO:
- [x] add workflow file
- [ ] check if a special `secrets.GITHUB_TOKEN` needs to be configured for dependabot